### PR TITLE
Require minimum Java version 8 when building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>1.8.0</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Both the  CodeGuru Profiler java agent as well as our demo application only work on JDK >= 8.

When running on an older JDK, the error messages were a bit cryptic:

```
$ sdk use java 7.0.262-zulu

Using java version 7.0.262-zulu in this shell.
$ java -version
openjdk version "1.7.0_262"
OpenJDK Runtime Environment (Zulu 7.38.0.11-CA-linux64) (build 1.7.0_262-b10)
OpenJDK 64-Bit Server VM (Zulu 7.38.0.11-CA-linux64) (build 24.262-b10, mixed mode)
$ mvn install
[INFO] Scanning for projects...
[INFO]
[INFO] --------------------< org.example:DemoApplication >---------------------
[INFO] Building DemoApplication 1.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ DemoApplication ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 2 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ DemoApplication ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 5 source files to target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.543 s
[INFO] Finished at: 2020-07-16T10:34:26+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project DemoApplication: Fatal error compiling: invalid target release: 8 -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

```

By adding the maven enforcer plugin, we can turn the above error into

```
$ mvn install
[INFO] Scanning for projects...
[INFO]
[INFO] --------------------< org.example:DemoApplication >---------------------
[INFO] Building DemoApplication 1.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-java) @ DemoApplication ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
Detected JDK Version: 1.7.0-262 is not in the allowed range 1.8.0.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.206 s
[INFO] Finished at: 2020-07-16T10:37:28+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce (enforce-java) on project DemoApplication: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

which seems a bit better.

I've also validated that the build still works correctly on Correto 8 and AdoptOpenJDK 14.
