### PR TITLE
Fix SQS URL example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ optimized version of the application compares to one with performance issues.
 
 ```bash
 # These need to be set according to your setup:
-export DEMO_APP_SQS_URL=https://sqs.YOUR-AWS-REGION.queue.amazonaws.com/YOUR-ACCOUNT-ID/DemoApplicationQueue
+export DEMO_APP_SQS_URL=https://sqs.YOUR-AWS-REGION.amazonaws.com/YOUR-ACCOUNT-ID/DemoApplicationQueue
 export DEMO_APP_BUCKET_NAME=demo-application-test-bucket-1092734-YOUR-BUCKET-REPLACE-ME
 export AWS_CODEGURU_TARGET_REGION=YOUR-AWS-REGION
 
@@ -79,7 +79,7 @@ java -javaagent:codeguru-profiler-java-agent-standalone-1.0.0.jar \
 
 ```bash
 # These need to be set according to your setup:
-export DEMO_APP_SQS_URL=https://sqs.YOUR-AWS-REGION.queue.amazonaws.com/YOUR-ACCOUNT-ID/DemoApplicationQueue
+export DEMO_APP_SQS_URL=https://sqs.YOUR-AWS-REGION.amazonaws.com/YOUR-ACCOUNT-ID/DemoApplicationQueue
 export DEMO_APP_BUCKET_NAME=demo-application-test-bucket-1092734-YOUR-BUCKET-REPLACE-ME
 export AWS_CODEGURU_TARGET_REGION=YOUR-AWS-REGION
 


### PR DESCRIPTION
Issue #, if available:

Description of changes: 

I changed the format of the SQS URL because I think “queue” is unnecessary.

`https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue`

* [Amazon SQS queue and message identifiers - Amazon Simple Queue Service](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.