### PR TITLE
Upgrade agent to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export AWS_CODEGURU_TARGET_REGION=YOUR-AWS-REGION
 # Run the demo!
 export AWS_CODEGURU_PROFILER_GROUP_NAME=DemoApplication-WithIssues
 mvn clean install # generates the DemoApplication-1.0-jar-with-dependencies.jar
-java -javaagent:codeguru-profiler-java-agent-standalone-1.0.3.jar \
+java -javaagent:codeguru-profiler-java-agent-standalone-1.1.0.jar \
   -jar target/DemoApplication-1.0-jar-with-dependencies.jar with-issues
 ```
 
@@ -86,7 +86,7 @@ export AWS_CODEGURU_TARGET_REGION=YOUR-AWS-REGION
 # Run the demo!
 export AWS_CODEGURU_PROFILER_GROUP_NAME=DemoApplication-WithoutIssues
 mvn clean install # generates the DemoApplication-1.0-jar-with-dependencies.jar
-java -javaagent:codeguru-profiler-java-agent-standalone-1.0.3.jar \
+java -javaagent:codeguru-profiler-java-agent-standalone-1.1.0.jar \
   -jar target/DemoApplication-1.0-jar-with-dependencies.jar without-issues
 ```
 


### PR DESCRIPTION
1.1.0 was recently released, updating the demo app to use it.
Got the jar file from https://repo1.maven.org/maven2/software/amazon/codeguruprofiler/codeguru-profiler-java-agent-standalone/1.1.0/codeguru-profiler-java-agent-standalone-1.1.0.jar

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
